### PR TITLE
Nan, Inf and -Inf are ignored

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/ryotarai/prometheus-tsdb-dump/pkg/writer"
 	"log"
 	"math"
 	"os"
 	"strings"
+
+	"github.com/ryotarai/prometheus-tsdb-dump/pkg/writer"
 
 	gokitlog "github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
@@ -98,6 +99,9 @@ func run(blockPath string, labelKey string, labelValue string, outFormat string,
 			for it.Next() {
 				t, v := it.At()
 				if math.IsNaN(v) {
+					continue
+				}
+				if math.IsInf(v, -1) || math.IsInf(v, 1) {
 					continue
 				}
 				if t < minTimestamp || maxTimestamp < t {


### PR DESCRIPTION
Hi,

we ran into an issue using your (super useful!) tool: our TSDB sometimes has `+Inf` and `-Inf` values, and they don't translate well to JSON. This PR ignores them, like you already do with `NaN`.


